### PR TITLE
feature/SIM-1209/splitOffGalSim

### DIFF
--- a/ups/lsst_sims.table
+++ b/ups/lsst_sims.table
@@ -1,4 +1,5 @@
 setupRequired(sims_maf)
+setupRequired(sims_GalSimInterface)
 setupRequired(sims_catUtils)
 setupRequired(sims_catalogs_generation)
 setupRequired(sims_catalogs_measures)


### PR DESCRIPTION
this pull request add sims_GalSimInterface to the list of dependencies in the lsst_sims.table file
